### PR TITLE
fix mapping of AbstractNode boolean methods

### DIFF
--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNodeImpl.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/AbstractNodeImpl.java
@@ -1,11 +1,10 @@
 package org.asciidoctor.ast;
 
-import org.asciidoctor.internal.RubyHashUtil;
-import org.jruby.Ruby;
-import org.jruby.RubyString;
-
 import java.util.List;
 import java.util.Map;
+
+import org.asciidoctor.internal.RubyHashUtil;
+import org.jruby.Ruby;
 
 public abstract class AbstractNodeImpl implements AbstractNode {
 

--- a/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Document.java
+++ b/asciidoctorj-core/src/main/java/org/asciidoctor/ast/Document.java
@@ -7,7 +7,6 @@ import org.asciidoctor.internal.RubyHashUtil;
 import org.asciidoctor.internal.RubyUtils;
 import org.jruby.Ruby;
 import org.jruby.RubyHash;
-import org.jruby.RubyObject;
 import org.jruby.runtime.builtin.IRubyObject;
 
 public class Document extends AbstractBlockImpl implements DocumentRuby {

--- a/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
+++ b/asciidoctorj-core/src/main/resources/org/asciidoctor/internal/asciidoctorclass.rb
@@ -100,3 +100,15 @@ class AsciidoctorModule
         return Asciidoctor::VERSION
     end
 end
+
+module Asciidoctor
+    class AbstractNode
+        alias :is_attr :attr? unless respond_to? :is_attr
+        alias :get_attr :attr unless respond_to? :get_attr
+        alias :is_reftext :reftext? unless respond_to? :is_reftext
+    end
+    
+    class AbstractBlock
+        alias :append :<< unless respond_to? :append
+    end
+end

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/WhenAsciiDocIsRenderedToDocument.java
@@ -122,7 +122,7 @@ public class WhenAsciiDocIsRenderedToDocument {
     @Test
     public void should_return_if_it_is_block() {
         Document document = asciidoctor.load(DOCUMENT, new HashMap<String, Object>());
-        assertThat(document.isBlock(), is(false));
+        assertThat(document.isBlock(), is(true));
     }
 
     @Test
@@ -132,8 +132,8 @@ public class WhenAsciiDocIsRenderedToDocument {
                                                     .compact(true).asMap();
         Document document = asciidoctor.load(DOCUMENT, options);
         assertThat(document.getAttributes(), hasKey("encoding"));
-        assertThat(document.isAttr("encoding", "UTF-8", true), is(true));
-        assertThat(document.getAttr("encoding", "", true).toString(), is("UTF-8"));
+        assertThat(document.isAttr("encoding", "UTF-8", false), is(true));
+        assertThat(document.getAttr("encoding", "", false).toString(), is("UTF-8"));
     }
 
     @Test

--- a/asciidoctorj-core/src/test/java/org/asciidoctor/converter/TextConverter.java
+++ b/asciidoctorj-core/src/test/java/org/asciidoctor/converter/TextConverter.java
@@ -13,9 +13,6 @@ public class TextConverter extends AbstractConverter {
 
     private String LINE_SEPARATOR = "\n";
 
-    private String backend;
-    private Map<Object, Object> opts;
-
     public TextConverter(String backend, Map<Object, Object> opts) {
         super(backend, opts);
     }


### PR DESCRIPTION
- help JRuby locate the underlying Ruby method using method aliasing
