### PR TITLE
added provided configuration based on nebula extra-configurations plugin

### DIFF
--- a/asciidoctorj-arquillian-extension/build.gradle
+++ b/asciidoctorj-arquillian-extension/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  compile project(path: ':asciidoctorj')
+  provided project(path: ':asciidoctorj')
   compile project(path: ':asciidoctorj-test-support', configuration: 'tests')
   compile "org.jboss.arquillian.container:arquillian-container-spi:$arquillianVersion"
   compile "org.jboss.arquillian.container:arquillian-container-test-spi:$arquillianVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
   }
   dependencies {
     if (JavaVersion.current().isJava7Compatible()) {
-      classpath 'com.netflix.nebula:nebula-publishing-plugin:2.0.0'
+      classpath 'com.netflix.nebula:nebula-publishing-plugin:2.2.+'
     }
   }
 }
@@ -67,6 +67,7 @@ subprojects {
   def _status = status
   apply plugin: 'java'
   apply plugin: 'groovy'
+  apply from: "$rootDir/gradle/providedConfiguration.gradle"
   status = _status
 
   // NOTE sourceCompatibility & targetCompatibility are set in gradle.properties to meet requirements of Gradle

--- a/gradle/providedConfiguration.gradle
+++ b/gradle/providedConfiguration.gradle
@@ -1,0 +1,19 @@
+/**
+ * Adds a configuration named 'provided'. 'Provided' dependencies
+ * are incoming compile dependencies that aren't outgoing
+ * dependencies. In other words, they have no effect on transitive
+ * dependency management.
+ */
+
+configurations {
+    provided
+    compile.extendsFrom provided
+
+    provided.allDependencies.all { Dependency dep ->
+        project.configurations.default.exclude(group: dep.group, module: dep.name)
+    }
+}
+
+plugins.withType(IdeaPlugin) {
+    idea.module.scopes.PROVIDED.plus = [ configurations.provided ]
+}

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -90,6 +90,15 @@ afterEvaluate {
       rootNode.name[0].setValue(project.properName)
       // FIXME I'm slightly annoyed that the dependencies node comes before name and description
       rootNode.children().last() + projectMeta
+
+      // Replace dependency "runtime" scope element value with "provided"
+      rootNode.dependencies.dependency.findAll {
+        it.scope.text() == JavaPlugin.RUNTIME_CONFIGURATION_NAME && configurations.provided.allDependencies.find { dep ->
+          dep.name == it.artifactId.text()
+        }
+      }.each { runtimeDep ->
+        runtimeDep.scope*.value = 'provided'
+      }
     }
   }
 }


### PR DESCRIPTION
This allows to add provided compile dependencies that aren't outgoing dependencies.
There is a nebula extra-configurations-plugin which is incompatible with java6.
Like the rest of nebula-plugins obviously :(
